### PR TITLE
Adds logging configuration and updates README

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,83 +161,100 @@ nessus-agent:
 
 ## Logging Configuration
 
-Common to both Windows and Linux are the parameters to configure the logging
-rotation and size.  To apply these settings, add them to the `nessus-agent:lookup`
-pillar dictionary.  These parameters are _optional_ and are not required to be
-configured in the pillar dictionary.
+There is an option to configure a custom log retention policy for each log file that
+is available within the Nessus Agent.  The `log.json` file contains definitions for
+the reporters which define the log files and logging formats.
 
-The rotation and size of the logging system can be controlled by setting the following
-parameters:
+The `log.json` is located in the following directories:
 
--   [Rotation Strategy](#nessus-agentlookuplog_rotation_strategy)
--   [Rotation Time](#nessus-agentlookuplog_rotation_time)
--   [Max Size](#nessus-agentlookuplog_max_size)
--   [Max Files](#nessus-agentlookuplog_max_files)
+Linux:  `/opt/nessus_agent/var/nessus/log.json`
 
-For more information, please refer to vendor documentation:
+Windows:  `C:\ProgramData\Tenable\Nessus Agent\nessus\log.json`
+
+Changing the default log retention policy can be done by modifying the `log.json`
+file and adding the following parameters to each reporter definition:
+
+-   Rotation Strategy
+-   Rotation Time
+-   Max Size
+-   Max Files
+
+The logging configuration is _optional_ and is not required as part of the Nessus Agent
+installation.
+
+For more information, please refer to the vendor documentation:
 
 [How to Manage Nessus log size and rotation](https://community.tenable.com/s/article/How-to-manage-Nessus-log-size-and-rotation)
 
-### `nessus-agent:lookup:log_rotation_strategy`
-
-The `log_rotation_strategy` parameter can be set to `daily` or `size`.
-
-**Required**: `False`
->
->**Default**: ``
-
-**Example**:
+To configure a custom log retention policy, the parameters must be added to the
+`nessus-agent:lookup` pillar definition in the following structure:
 
 ```yaml
 nessus-agent:
   lookup:
-    log_rotation_strategy: 'daily'
+    log_config:
+      <file-path-to-log-file>:
+        rotation_strategy: ''
+        rotation_size: ''
+        max_size: ''
+        max_files: ''
 ```
 
-### `nessus-agent:lookup:log_rotation_time`
+### `nessus-agent:lookup:log_config`
 
-The `log_rotation_time` parameter is the rotation time in `seconds`.  Used when `log_rotation_strategy` is set to `"daily"`.
+`log_config` is the main heading that begins the logging configuration.
 
-**Required**: `False`
->
->**Default**: ``
+### `nessus-agent:lookup:log_config:<file-path-to-log-file>`
 
-**Example**:
+`<file-path-to-log-file>` identifies the log file path that is present in the
+`log.json` reporter definitions.
+
+Add additional `<file-path-to-log-file>` sections to the pillar, if desired, for
+other reporters present within `log.json`.
+
+A reporter containing the log file path must be present in `log.json` or
+the logging configurations will not be added.  Adding additional reporters to
+`log.json` is outside the scope of the Nessus Agent Salt formula.
+
+### `nessus-agent:lookup:<file-path-to-log-file>:rotation_strategy`
+
+The `rotation_strategy` parameter can be set to `daily` or `size`.
+
+### `nessus-agent:lookup:<file-path-to-log-file>:rotation_time`
+
+The `rotation_time` parameter is the rotation time in `seconds`.  Used when
+`rotation_strategy` is set to `daily`.
+
+### `nessus-agent:lookup:<file-path-to-log-file>:max_size`
+
+The `max_size` parameter is the rotation size in `bytes`.  Used when
+`rotation_strategy` is set to `size`.
+
+### `nessus-agent:lookup:<file-path-to-log-file>:max_files`
+
+The `max_files` parameter is the maximum number of files retained in the file
+rotation.  Used whether `rotation_strategy` is set to `daily` or `size`.
+
+### **Example (Linux)**:
 
 ```yaml
 nessus-agent:
   lookup:
-    log_rotation_time: '86400'
+    log_config:
+      /opt/nessus_agent/var/nessus/logs/www_server.log:
+        rotation_strategy: 'size'
+        max_size: '268435456'
+        max_files: '512'
 ```
 
-### `nessus-agent:lookup:log_max_size`
-
-The `log_max_size` parameter is the rotation size in `bytes`.  Used when `log_rotation_strategy` is set to `"size"`.
-
-**Required**: `False`
->
->**Default**: ``
-
-**Example**:
+### **Example (Windows)**:
 
 ```yaml
 nessus-agent:
   lookup:
-    log_max_size: '134217728'
-```
-
-### `nessus-agent:lookup:log_max_files`
-
-The `log_max_files` parameter is the maximum number of files allowed.
-
-**Required**: `False`
->
->**Default**: ``
-
-**Example**:
-
-```yaml
-nessus-agent:
-  lookup:
-    log_max_files: '256'
+    log_config:
+      c:\\\\ProgramData\\\\Tenable\\\\Nessus Agent\\\\nessus\\\\logs\\\\www_server.log:
+        rotation_strategy: 'daily'
+        rotation_time: '86400'
+        max_files: '1024'
 ```

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # nessus-agent-formula
 
-This Salt formula will install the Nessus Agent and, if all parametes are
-provided, will also link the agent to a Nessus server.  This formula supports
+This Salt formula will install the Nessus Agent and, if all Nessus server parameters
+are provided, will also link the agent to the server.  This formula supports
 both Windows and Linux.
 
 On Windows, the formula depends on the Salt Windows Package Manager (`winrepo`),
@@ -157,4 +157,87 @@ The `nessus_groups` parameter is a group name where the Nessus agent will be ass
 nessus-agent:
   lookup:
     nessus_groups: 'NessusAgents'
+```
+
+## Logging Configuration
+
+Common to both Windows and Linux are the parameters to configure the logging
+rotation and size.  To apply these settings, add them to the `nessus-agent:lookup`
+pillar dictionary.  These parameters are _optional_ and are not required to be
+configured in the pillar dictionary.
+
+The rotation and size of the logging system can be controlled by setting the following
+parameters:
+
+-   [Rotation Strategy](#nessus-agentlookuplog_rotation_strategy)
+-   [Rotation Time](#nessus-agentlookuplog_rotation_time)
+-   [Max Size](#nessus-agentlookuplog_max_size)
+-   [Max Files](#nessus-agentlookuplog_max_files)
+
+For more information, please refer to vendor documentation:
+
+[How to Manage Nessus log size and rotation](https://community.tenable.com/s/article/How-to-manage-Nessus-log-size-and-rotation)
+
+### `nessus-agent:lookup:log_rotation_strategy`
+
+The `log_rotation_strategy` parameter can be set to `daily` or `size`.
+
+**Required**: `False`
+>
+>**Default**: ``
+
+**Example**:
+
+```yaml
+nessus-agent:
+  lookup:
+    log_rotation_strategy: 'daily'
+```
+
+### `nessus-agent:lookup:log_rotation_time`
+
+The `log_rotation_time` parameter is the rotation time in `seconds`.  Used when `log_rotation_strategy` is set to `"daily"`.
+
+**Required**: `False`
+>
+>**Default**: ``
+
+**Example**:
+
+```yaml
+nessus-agent:
+  lookup:
+    log_rotation_time: '86400'
+```
+
+### `nessus-agent:lookup:log_max_size`
+
+The `log_max_size` parameter is the rotation size in `bytes`.  Used when `log_rotation_strategy` is set to `"size"`.
+
+**Required**: `False`
+>
+>**Default**: ``
+
+**Example**:
+
+```yaml
+nessus-agent:
+  lookup:
+    log_max_size: '134217728'
+```
+
+### `nessus-agent:lookup:log_max_files`
+
+The `log_max_files` parameter is the maximum number of files allowed.
+
+**Required**: `False`
+>
+>**Default**: ``
+
+**Example**:
+
+```yaml
+nessus-agent:
+  lookup:
+    log_max_files: '256'
 ```

--- a/nessus-agent/elx/init.sls
+++ b/nessus-agent/elx/init.sls
@@ -30,42 +30,42 @@ Print nessus-agent help:
         without linking the agent to the server.
 {%- endif %}
 
-{%- if (nessus.log_rotation_strategy) %}
+{%- if nessus.log_rotation_strategy %}
 Add Log Rotation Strategy:
   file.replace:
-    - name: '/opt/nessus_agent/var/nessus/log.json'
+    - name: /opt/nessus_agent/var/nessus/log.json
     - pattern: '"file": "/opt/nessus_agent/var/nessus/logs/www_server.log"'
-    - repl: '"rotation_strategy": {{nessus.log_rotation_strategy}},\n\t\t\g<0>'
+    - repl: '"rotation_strategy": "{{nessus.log_rotation_strategy}}",\n                \g<0>'
     - watch:
       - cmd: Pause For Log File
 {%- endif %}
 
-{%- if (nessus.log_rotation_time) %}
+{%- if nessus.log_rotation_time %}
 Add Log Rotation Time:
   file.replace:
-    - name: '/opt/nessus_agent/var/nessus/log.json'
+    - name: /opt/nessus_agent/var/nessus/log.json
     - pattern: '"file": "/opt/nessus_agent/var/nessus/logs/www_server.log"'
-    - repl: '"rotation_time": {{nessus.log_rotation_time}},\n\t\t\g<0>'
+    - repl: '"rotation_time": "{{nessus.log_rotation_time}}",\n                \g<0>'
     - watch:
       - cmd: Pause For Log File
 {%- endif %}
 
-{%- if (nessus.log_max_size) %}
+{%- if nessus.log_max_size %}
 Add Log Max Size:
   file.replace:
-    - name: '/opt/nessus_agent/var/nessus/log.json'
+    - name: /opt/nessus_agent/var/nessus/log.json
     - pattern: '"file": "/opt/nessus_agent/var/nessus/logs/www_server.log"'
-    - repl: '"max_size": {{nessus.log_max_size}},\n\t\t\g<0>'
+    - repl: '"max_size": "{{nessus.log_max_size}}",\n                \g<0>'
     - watch:
       - cmd: Pause For Log File
 {%- endif %}
 
-{%- if (nessus.log_max_files) %}
+{%- if nessus.log_max_files %}
 Add Log Max Files:
   file.replace:
-    - name: '/opt/nessus_agent/var/nessus/log.json'
+    - name: /opt/nessus_agent/var/nessus/log.json
     - pattern: '"file": "/opt/nessus_agent/var/nessus/logs/www_server.log"'
-    - repl: '"max_files": {{nessus.log_max_files}},\n\t\t\g<0>'
+    - repl: '"max_files": "{{nessus.log_max_files}}",\n                \g<0>'
     - watch:
       - cmd: Pause For Log File
 {%- endif %}

--- a/nessus-agent/elx/init.sls
+++ b/nessus-agent/elx/init.sls
@@ -30,6 +30,75 @@ Print nessus-agent help:
         without linking the agent to the server.
 {%- endif %}
 
+{%- if (nessus.log_rotation_strategy) %}
+Add Log Rotation Strategy:
+  file.replace:
+    - name: '/opt/nessus_agent/var/nessus/log.json'
+    - pattern: '"file": "/opt/nessus_agent/var/nessus/logs/www_server.log"'
+    - repl: '"rotation_strategy": {{nessus.log_rotation_strategy}},\n\t\t\g<0>'
+    - watch:
+      - cmd: Pause For Log File
+{%- endif %}
+
+{%- if (nessus.log_rotation_time) %}
+Add Log Rotation Time:
+  file.replace:
+    - name: '/opt/nessus_agent/var/nessus/log.json'
+    - pattern: '"file": "/opt/nessus_agent/var/nessus/logs/www_server.log"'
+    - repl: '"rotation_time": {{nessus.log_rotation_time}},\n\t\t\g<0>'
+    - watch:
+      - cmd: Pause For Log File
+{%- endif %}
+
+{%- if (nessus.log_max_size) %}
+Add Log Max Size:
+  file.replace:
+    - name: '/opt/nessus_agent/var/nessus/log.json'
+    - pattern: '"file": "/opt/nessus_agent/var/nessus/logs/www_server.log"'
+    - repl: '"max_size": {{nessus.log_max_size}},\n\t\t\g<0>'
+    - watch:
+      - cmd: Pause For Log File
+{%- endif %}
+
+{%- if (nessus.log_max_files) %}
+Add Log Max Files:
+  file.replace:
+    - name: '/opt/nessus_agent/var/nessus/log.json'
+    - pattern: '"file": "/opt/nessus_agent/var/nessus/logs/www_server.log"'
+    - repl: '"max_files": {{nessus.log_max_files}},\n\t\t\g<0>'
+    - watch:
+      - cmd: Pause For Log File
+{%- endif %}
+
+Pause For Log File:
+  cmd.run:
+    - name: sleep 5
+    - watch:
+      - cmd: Start Nessus Agent
+
+Pre-Create Nessus Log Directory:
+  file.directory:
+    - name: /var/log/nessus/logs
+    - user: root
+    - group: root
+    - dir_mode: 0755
+    - recurse:
+      - user
+      - group
+      - mode
+    - makedirs: True
+
+Create Sym-link To Log Dir:
+  file.symlink:
+    - name: /opt/nessus_agent/var/nessus/logs
+    - target: /var/log/nessus/logs
+    - user: root
+    - group: root
+    - mode: 0755
+    - makedirs: True
+    - require:
+      - file: Pre-Create Nessus Log Directory
+
 Start Nessus Agent:
   cmd.run:
     - name: /sbin/service nessusagent start
@@ -44,3 +113,5 @@ Install Nessus Package:
 {%- elif salt.grains.get('osmajorrelease') == '6'%}
       - {{ nessus.package }}: {{ nessus.package_url_es6 }}
 {%- endif %}
+    - require:
+      - file: Create Sym-link To Log Dir

--- a/nessus-agent/elx/init.sls
+++ b/nessus-agent/elx/init.sls
@@ -30,45 +30,17 @@ Print nessus-agent help:
         without linking the agent to the server.
 {%- endif %}
 
-{%- if nessus.log_rotation_strategy %}
-Add Log Rotation Strategy:
+{%- for log_file,log_rotation in nessus.log_config.items() %}
+  {%- for rotation_param,rotation_value in log_rotation.items() %}
+Add Log Config {{ log_file }} {{ rotation_param }}:
   file.replace:
     - name: /opt/nessus_agent/var/nessus/log.json
-    - pattern: '"file": "/opt/nessus_agent/var/nessus/logs/www_server.log"'
-    - repl: '"rotation_strategy": "{{nessus.log_rotation_strategy}}",\n                \g<0>'
+    - pattern: '"file": "{{ log_file }}"'
+    - repl: '"{{ rotation_param }}": "{{ rotation_value }}",\n                \g<0>'
     - watch:
       - cmd: Pause For Log File
-{%- endif %}
-
-{%- if nessus.log_rotation_time %}
-Add Log Rotation Time:
-  file.replace:
-    - name: /opt/nessus_agent/var/nessus/log.json
-    - pattern: '"file": "/opt/nessus_agent/var/nessus/logs/www_server.log"'
-    - repl: '"rotation_time": "{{nessus.log_rotation_time}}",\n                \g<0>'
-    - watch:
-      - cmd: Pause For Log File
-{%- endif %}
-
-{%- if nessus.log_max_size %}
-Add Log Max Size:
-  file.replace:
-    - name: /opt/nessus_agent/var/nessus/log.json
-    - pattern: '"file": "/opt/nessus_agent/var/nessus/logs/www_server.log"'
-    - repl: '"max_size": "{{nessus.log_max_size}}",\n                \g<0>'
-    - watch:
-      - cmd: Pause For Log File
-{%- endif %}
-
-{%- if nessus.log_max_files %}
-Add Log Max Files:
-  file.replace:
-    - name: /opt/nessus_agent/var/nessus/log.json
-    - pattern: '"file": "/opt/nessus_agent/var/nessus/logs/www_server.log"'
-    - repl: '"max_files": "{{nessus.log_max_files}}",\n                \g<0>'
-    - watch:
-      - cmd: Pause For Log File
-{%- endif %}
+  {%- endfor %}
+{%- endfor %}
 
 Pause For Log File:
   cmd.run:

--- a/nessus-agent/elx/map.jinja
+++ b/nessus-agent/elx/map.jinja
@@ -7,10 +7,7 @@ nessus_server: ''
 nessus_key: ''
 nessus_port: ''
 nessus_groups: ''
-log_rotation_strategy: ''
-log_rotation_time: ''
-log_max_size: ''
-log_max_files: ''
+log_config: {}
 
 {%- endload %}
 

--- a/nessus-agent/elx/map.jinja
+++ b/nessus-agent/elx/map.jinja
@@ -7,6 +7,10 @@ nessus_server: ''
 nessus_key: ''
 nessus_port: ''
 nessus_groups: ''
+log_rotation_strategy: ''
+log_rotation_time: ''
+log_max_size: ''
+log_max_files: ''
 
 {%- endload %}
 

--- a/nessus-agent/windows/init.sls
+++ b/nessus-agent/windows/init.sls
@@ -6,42 +6,42 @@
 # In addiont, the sls file requires that the salt winrepo has been
 # configured with a `nessus agent` pkg definition
 
-{%- if (nessus.log_rotation_strategy) %}
+{%- if nessus.log_rotation_strategy %}
 Add Log Rotation Strategy:
   file.replace:
-    - name: 'C:\ProgramData\Tenable\Nessus Agent\nessus\log.json'
+    - name: C:\ProgramData\Tenable\Nessus Agent\nessus\log.json
     - pattern: '"file": "c:\\\\ProgramData\\\\Tenable\\\\Nessus Agent\\\\nessus\\\\logs\\\\www_server.log"'
-    - repl: '"rotation_strategy": {{nessus.log_rotation_strategy}},\n\t\t\t\t\g<0>'
+    - repl: '"rotation_strategy": "{{nessus.log_rotation_strategy}}",\n                \g<0>'
     - watch:
       - pkg: install-nessus-agent
 {%- endif %}
 
-{%- if (nessus.log_rotation_time) %}
+{%- if nessus.log_rotation_time %}
 Add Log Rotation Time:
   file.replace:
-    - name: 'C:\ProgramData\Tenable\Nessus Agent\nessus\log.json'
+    - name: C:\ProgramData\Tenable\Nessus Agent\nessus\log.json
     - pattern: '"file": "c:\\\\ProgramData\\\\Tenable\\\\Nessus Agent\\\\nessus\\\\logs\\\\www_server.log"'
-    - repl: '"rotation_time": {{nessus.log_rotation_time}},\n\t\t\t\t\g<0>'
+    - repl: '"rotation_time": "{{nessus.log_rotation_time}}",\n                \g<0>'
     - watch:
       - pkg: install-nessus-agent
 {%- endif %}
 
-{%- if (nessus.log_max_size) %}
+{%- if nessus.log_max_size %}
 Add Log Max Size:
   file.replace:
-    - name: 'C:\ProgramData\Tenable\Nessus Agent\nessus\log.json'
+    - name: C:\ProgramData\Tenable\Nessus Agent\nessus\log.json
     - pattern: '"file": "c:\\\\ProgramData\\\\Tenable\\\\Nessus Agent\\\\nessus\\\\logs\\\\www_server.log"'
-    - repl: '"max_size": {{nessus.log_max_size}},\n\t\t\t\t\g<0>'
+    - repl: '"max_size": "{{nessus.log_max_size}}",\n                \g<0>'
     - watch:
       - pkg: install-nessus-agent
 {%- endif %}
 
-{%- if (nessus.log_max_files) %}
+{%- if nessus.log_max_files %}
 Add Log Max Files:
   file.replace:
-    - name: 'C:\ProgramData\Tenable\Nessus Agent\nessus\log.json'
+    - name: C:\ProgramData\Tenable\Nessus Agent\nessus\log.json
     - pattern: '"file": "c:\\\\ProgramData\\\\Tenable\\\\Nessus Agent\\\\nessus\\\\logs\\\\www_server.log"'
-    - repl: '"max_files": {{nessus.log_max_files}},\n\t\t\t\t\g<0>'
+    - repl: '"max_files": "{{nessus.log_max_files}}",\n                \g<0>'
     - watch:
       - pkg: install-nessus-agent
 {%- endif %}

--- a/nessus-agent/windows/init.sls
+++ b/nessus-agent/windows/init.sls
@@ -6,45 +6,17 @@
 # In addiont, the sls file requires that the salt winrepo has been
 # configured with a `nessus agent` pkg definition
 
-{%- if nessus.log_rotation_strategy %}
-Add Log Rotation Strategy:
+{%- for log_file,log_rotation in nessus.log_config.items() %}
+  {%- for rotation_param,rotation_value in log_rotation.items() %}
+Add Log Config {{ log_file }} {{ rotation_param }}:
   file.replace:
     - name: C:\ProgramData\Tenable\Nessus Agent\nessus\log.json
-    - pattern: '"file": "c:\\\\ProgramData\\\\Tenable\\\\Nessus Agent\\\\nessus\\\\logs\\\\www_server.log"'
-    - repl: '"rotation_strategy": "{{nessus.log_rotation_strategy}}",\n                \g<0>'
+    - pattern: '"file": "{{ log_file }}"'
+    - repl: '"{{ rotation_param }}": "{{ rotation_value }}",\n                \g<0>'
     - watch:
       - pkg: install-nessus-agent
-{%- endif %}
-
-{%- if nessus.log_rotation_time %}
-Add Log Rotation Time:
-  file.replace:
-    - name: C:\ProgramData\Tenable\Nessus Agent\nessus\log.json
-    - pattern: '"file": "c:\\\\ProgramData\\\\Tenable\\\\Nessus Agent\\\\nessus\\\\logs\\\\www_server.log"'
-    - repl: '"rotation_time": "{{nessus.log_rotation_time}}",\n                \g<0>'
-    - watch:
-      - pkg: install-nessus-agent
-{%- endif %}
-
-{%- if nessus.log_max_size %}
-Add Log Max Size:
-  file.replace:
-    - name: C:\ProgramData\Tenable\Nessus Agent\nessus\log.json
-    - pattern: '"file": "c:\\\\ProgramData\\\\Tenable\\\\Nessus Agent\\\\nessus\\\\logs\\\\www_server.log"'
-    - repl: '"max_size": "{{nessus.log_max_size}}",\n                \g<0>'
-    - watch:
-      - pkg: install-nessus-agent
-{%- endif %}
-
-{%- if nessus.log_max_files %}
-Add Log Max Files:
-  file.replace:
-    - name: C:\ProgramData\Tenable\Nessus Agent\nessus\log.json
-    - pattern: '"file": "c:\\\\ProgramData\\\\Tenable\\\\Nessus Agent\\\\nessus\\\\logs\\\\www_server.log"'
-    - repl: '"max_files": "{{nessus.log_max_files}}",\n                \g<0>'
-    - watch:
-      - pkg: install-nessus-agent
-{%- endif %}
+  {%- endfor %}
+{%- endfor %}
 
 install-nessus-agent:
   pkg.installed:

--- a/nessus-agent/windows/init.sls
+++ b/nessus-agent/windows/init.sls
@@ -6,6 +6,46 @@
 # In addiont, the sls file requires that the salt winrepo has been
 # configured with a `nessus agent` pkg definition
 
+{%- if (nessus.log_rotation_strategy) %}
+Add Log Rotation Strategy:
+  file.replace:
+    - name: 'C:\ProgramData\Tenable\Nessus Agent\nessus\log.json'
+    - pattern: '"file": "c:\\\\ProgramData\\\\Tenable\\\\Nessus Agent\\\\nessus\\\\logs\\\\www_server.log"'
+    - repl: '"rotation_strategy": {{nessus.log_rotation_strategy}},\n\t\t\t\t\g<0>'
+    - watch:
+      - pkg: install-nessus-agent
+{%- endif %}
+
+{%- if (nessus.log_rotation_time) %}
+Add Log Rotation Time:
+  file.replace:
+    - name: 'C:\ProgramData\Tenable\Nessus Agent\nessus\log.json'
+    - pattern: '"file": "c:\\\\ProgramData\\\\Tenable\\\\Nessus Agent\\\\nessus\\\\logs\\\\www_server.log"'
+    - repl: '"rotation_time": {{nessus.log_rotation_time}},\n\t\t\t\t\g<0>'
+    - watch:
+      - pkg: install-nessus-agent
+{%- endif %}
+
+{%- if (nessus.log_max_size) %}
+Add Log Max Size:
+  file.replace:
+    - name: 'C:\ProgramData\Tenable\Nessus Agent\nessus\log.json'
+    - pattern: '"file": "c:\\\\ProgramData\\\\Tenable\\\\Nessus Agent\\\\nessus\\\\logs\\\\www_server.log"'
+    - repl: '"max_size": {{nessus.log_max_size}},\n\t\t\t\t\g<0>'
+    - watch:
+      - pkg: install-nessus-agent
+{%- endif %}
+
+{%- if (nessus.log_max_files) %}
+Add Log Max Files:
+  file.replace:
+    - name: 'C:\ProgramData\Tenable\Nessus Agent\nessus\log.json'
+    - pattern: '"file": "c:\\\\ProgramData\\\\Tenable\\\\Nessus Agent\\\\nessus\\\\logs\\\\www_server.log"'
+    - repl: '"max_files": {{nessus.log_max_files}},\n\t\t\t\t\g<0>'
+    - watch:
+      - pkg: install-nessus-agent
+{%- endif %}
+
 install-nessus-agent:
   pkg.installed:
     - name: {{ nessus.package }}

--- a/nessus-agent/windows/map.jinja
+++ b/nessus-agent/windows/map.jinja
@@ -3,6 +3,10 @@
 
 package: 'nessus-agent'
 version: ''
+log_rotation_strategy: ''
+log_rotation_time: ''
+log_max_size: ''
+log_max_files: ''
 
 {%- endload %}
 

--- a/nessus-agent/windows/map.jinja
+++ b/nessus-agent/windows/map.jinja
@@ -3,10 +3,7 @@
 
 package: 'nessus-agent'
 version: ''
-log_rotation_strategy: ''
-log_rotation_time: ''
-log_max_size: ''
-log_max_files: ''
+log_config: {}
 
 {%- endload %}
 

--- a/pillar.example
+++ b/pillar.example
@@ -14,8 +14,15 @@ nessus-agent:
 
     # `version` is the version of the agent to install. the version
     # must be available in the package repository.
-    #version: ''
+    #version: '7.0.3.20013'
 
+    # `log_config` sets the logging retention configuration for the desired log
+    # file within the Nessus Agent for the. 
+    #log_config:
+    #  c:\\\\ProgramData\\\\Tenable\\\\Nessus Agent\\\\nessus\\\\logs\\\\www_server.log:
+    #    rotation_strategy: 'daily'
+    #    rotation_time: '86400'
+    #    max_files: '512'
 
     #############################################################
     #
@@ -47,3 +54,11 @@ nessus-agent:
 
     # Nessus group name
     #nessus_groups: 'NessusAgents'
+
+    # `log_config` sets the logging retention configuration for the desired log
+    # file within the Nessus Agent for the.
+    #log_config:
+    #  /opt/nessus_agent/var/nessus/logs/www_server.log:
+    #    rotation_strategy: 'size'
+    #    max_size: '268435456'
+    #    max_files: '512'


### PR DESCRIPTION
Logging configuration added to Nessus Agent salt formula for both Linux and Windows.  Linux formula has an additional change of creating a symlink to redirect log files to `/var/log/nessus/logs`.

Closes #1 and closes #2 