### PR TITLE
Use Salt's service module to start the service

### DIFF
--- a/nessus-agent/elx/init.sls
+++ b/nessus-agent/elx/init.sls
@@ -46,7 +46,7 @@ Pause For Log File:
   cmd.run:
     - name: sleep 5
     - watch:
-      - cmd: Start Nessus Agent
+      - service: Start Nessus Agent
 
 Pre-Create Nessus Log Directory:
   file.directory:

--- a/nessus-agent/elx/init.sls
+++ b/nessus-agent/elx/init.sls
@@ -73,7 +73,7 @@ Create Sym-link To Log Dir:
 
 Start Nessus Agent:
   service.running:
-    - name: {{ nessus.package }}
+    - name: {{ nessus.package | lower }}
     - enable: True
     - require:
       - pkg: Install Nessus Package

--- a/nessus-agent/elx/init.sls
+++ b/nessus-agent/elx/init.sls
@@ -72,8 +72,9 @@ Create Sym-link To Log Dir:
       - file: Pre-Create Nessus Log Directory
 
 Start Nessus Agent:
-  cmd.run:
-    - name: /sbin/service nessusagent start
+  service.running:
+    - name: {{ service_name }}
+    - enable: True
     - require:
       - pkg: Install Nessus Package
 

--- a/nessus-agent/elx/init.sls
+++ b/nessus-agent/elx/init.sls
@@ -73,7 +73,7 @@ Create Sym-link To Log Dir:
 
 Start Nessus Agent:
   service.running:
-    - name: {{ service_name }}
+    - name: {{ nessus.package }}
     - enable: True
     - require:
       - pkg: Install Nessus Package


### PR DESCRIPTION
Every OS has different daemon service and evolves over time.
It's better to let Salt's "service" module handle the under pinnings
* https://docs.saltstack.com/en/latest/ref/modules/all/salt.modules.service.html